### PR TITLE
Fix/playlists page refresh

### DIFF
--- a/lib/pages/playlists_page.dart
+++ b/lib/pages/playlists_page.dart
@@ -22,69 +22,71 @@ class _PlaylistsPageState extends State<PlaylistsPage> {
   Widget build(BuildContext context) {
     final playlists = context.watch<PlaylistStore>().playlists;
 
-    if (playlists.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Assets.icons.lookingAtVoid.svg(
-              height: 250,
-              width: 250,
-            ),
-            const SizedBox(height: 10),
-            Text(
-              L10n.of(context)!.noPlaylistsFound,
-            ),
-          ],
-        ),
-      );
-    }
-
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.end,
-      children: [
-        Padding(
-          padding: const EdgeInsets.only(right: 10),
-          child: DropdownButton<String>(
-            value: currentSort,
-            icon: const Icon(Icons.filter_list),
-            items: [
-              for (var item in ['Sort by 0', 'Sort by 1', 'Sort by 2'])
-                DropdownMenuItem(
-                  value: item,
-                  child: Text(item),
-                ),
-            ],
-            onChanged: (value) {
-              setState(() {
-                currentSort = value!;
-              });
-            },
-          ),
-        ),
-        Observer(
-          builder: (_) => Expanded(
-            child: ListView.separated(
-              itemCount: playlists.length,
-              padding: const EdgeInsets.symmetric(
-                horizontal: 10,
-                vertical: 10,
+    return Observer(
+      builder: (_) => playlists.isEmpty
+          ? Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Assets.icons.lookingAtVoid.svg(
+                    height: 250,
+                    width: 250,
+                  ),
+                  const SizedBox(height: 10),
+                  Text(
+                    L10n.of(context)!.noPlaylistsFound,
+                  ),
+                ],
               ),
-              separatorBuilder: (context, index) => const SizedBox(height: 10),
-              itemBuilder: (context, index) {
-                final item = playlists[index];
+            )
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(right: 10),
+                  child: DropdownButton<String>(
+                    value: currentSort,
+                    icon: const Icon(Icons.filter_list),
+                    items: [
+                      for (var item in ['Sort by 0', 'Sort by 1', 'Sort by 2'])
+                        DropdownMenuItem(
+                          value: item,
+                          child: Text(item),
+                        ),
+                    ],
+                    onChanged: (value) {
+                      setState(() {
+                        currentSort = value!;
+                      });
+                    },
+                  ),
+                ),
+                Observer(
+                  builder: (_) => Expanded(
+                    child: ListView.separated(
+                      itemCount: playlists.length,
+                      padding: const EdgeInsets.symmetric(
+                        horizontal: 10,
+                        vertical: 10,
+                      ),
+                      separatorBuilder: (context, index) =>
+                          const SizedBox(height: 10),
+                      itemBuilder: (context, index) {
+                        final item = playlists[index];
 
-                return PlaylistsListItem(
-                  snippet: item.snippet!,
-                  icon: const Icon(Icons.delete),
-                  onPressedIcon: () =>
-                      context.read<PlaylistStore>().removePlaylistById(item.id),
-                );
-              },
+                        return PlaylistsListItem(
+                          snippet: item.snippet!,
+                          icon: const Icon(Icons.delete),
+                          onPressedIcon: () => context
+                              .read<PlaylistStore>()
+                              .removePlaylistById(item.id),
+                        );
+                      },
+                    ),
+                  ),
+                ),
+              ],
             ),
-          ),
-        ),
-      ],
     );
   }
 }


### PR DESCRIPTION
Playlists page is displayed correctly. There is no refresh needed after adding the first playlist. The "no playlists found" image is displayed immediately after deleting the last playlist as well.